### PR TITLE
Add highlight color settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/ArtyMaury/template-finder"
   },
-  "version": "1.3.2",
+  "version": "1.3.3",
   "publisher": "Artymaury",
   "license": "MIT",
   "engines": {
@@ -46,6 +46,21 @@
           "type": "boolean",
           "default": true,
           "description": "Indicate wether the variables values in the tooltip should be separated with dashes"
+        },
+        "templateFinder.display.colorAllMatching": {
+          "type": "string",
+          "default": "rgba(0,255,0,0.75)",
+          "description": "Variable highlight color if all match"
+        },
+        "templateFinder.display.colorSomeMatching": {
+          "type": "string",
+          "default": "rgba(255,140,0,0.75)",
+          "description": "Variable highlight color if some match"
+        },
+        "templateFinder.display.colorNoneMatching": {
+          "type": "string",
+          "default": "rgba(255,0,0,0.9)",
+          "description": "Variable highlight color if none match"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -49,17 +49,20 @@
         },
         "templateFinder.display.colorAllMatching": {
           "type": "string",
-          "default": "rgba(0,255,0,0.75)",
+          "format": "color",
+          "default": "#00cf00",
           "description": "Variable highlight color if all match"
         },
         "templateFinder.display.colorSomeMatching": {
           "type": "string",
-          "default": "rgba(255,140,0,0.75)",
+          "format": "color",
+          "default": "#e77f00",
           "description": "Variable highlight color if some match"
         },
         "templateFinder.display.colorNoneMatching": {
           "type": "string",
-          "default": "rgba(255,0,0,0.9)",
+          "format": "color",
+          "default": "#ef0000",
           "description": "Variable highlight color if none match"
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ export function activate(context: vscode.ExtensionContext) {
     console.log('settings changed');
     if (workspaceConfig.get<Array<boolean>>('extension.activated')) {
       triggerUpdate();
+      Decorator.init();
     }
   });
 

--- a/src/template_decorator.ts
+++ b/src/template_decorator.ts
@@ -73,6 +73,16 @@ export default {
   externalVariables: [] as Array<RegExp>,
 
   init: function () {
+    let allMatchingTemplateDecorationRenderOptions: vscode.DecorationRenderOptions = {
+      color: vscode.workspace.getConfiguration('templateFinder.display').get('colorAllMatching'),
+    }
+    let someMatchingTemplateDecorationRenderOptions: vscode.DecorationRenderOptions = {
+      color: vscode.workspace.getConfiguration('templateFinder.display').get('colorSomeMatching'),
+    }
+    let noneMatchingTemplateDecorationRenderOptions: vscode.DecorationRenderOptions = {
+      color: vscode.workspace.getConfiguration('templateFinder.display').get('colorNoneMatching'),
+    }
+
     allMatchingTemplateDecorator = vscode.window.createTextEditorDecorationType(
       allMatchingTemplateDecorationRenderOptions
     )
@@ -84,16 +94,6 @@ export default {
     )
     this.initiated = true
   },
-}
-
-const allMatchingTemplateDecorationRenderOptions: vscode.DecorationRenderOptions = {
-  color: 'rgba(0,255,0,0.75)',
-}
-const someMatchingTemplateDecorationRenderOptions: vscode.DecorationRenderOptions = {
-  color: 'rgba(255,140,0,0.75)',
-}
-const noneMatchingTemplateDecorationRenderOptions: vscode.DecorationRenderOptions = {
-  color: 'rgba(255,0,0,0.9)',
 }
 
 function createHoverMessage(lineSeparator: string, data: Template) {
@@ -113,7 +113,7 @@ function createHoverMessage(lineSeparator: string, data: Template) {
   if (data.defaultValue) {
     hoverMessage.appendMarkdown(
       lineSeparator +
-        `| **default** |
+      `| **default** |
 | ${beautifyValue(data.defaultValue)} |
 `
     )
@@ -125,7 +125,7 @@ function createHoverMessage(lineSeparator: string, data: Template) {
     if (data.objectMatch) {
       hoverMessage.appendMarkdown(
         lineSeparator +
-          `| **current context** |
+        `| **current context** |
 | ${beautifyValue(data.objectMatch)} |
 `
       )
@@ -136,9 +136,9 @@ function createHoverMessage(lineSeparator: string, data: Template) {
       let command = 'templateFinder.goto'
       hoverMessage.appendMarkdown(
         lineSeparator +
-          `| **[${shortLocation}](command:${command}?${encodeURIComponent(
-            JSON.stringify({ file, key: data.name })
-          )} "Go To Definition")** |
+        `| **[${shortLocation}](command:${command}?${encodeURIComponent(
+          JSON.stringify({ file, key: data.name })
+        )} "Go To Definition")** |
 | ${beautifyValue(data.variableMatches[file])} |
 `
       )


### PR DESCRIPTION
This adds three settings to configure the highlighting color of all, some and none matching variables.

I thought instead of opening an issue with a feature request I'd try to implement the change myself. Took me a while and it probably isn't the cleanest solution (especially reloading the color values) but maybe you could improve it a bit and then add it to the extension.